### PR TITLE
Fixed date range event after a range was fixed

### DIFF
--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -530,7 +530,8 @@
                 endDate = this.getEndDate();
 
             if(moment(startDate).diff(endDate) > 0){
-                this.endCalendar.updateSelectedDate(startDate);
+                this.endCalendar.updateSelectedDate(startDate, {silent: true});
+                endDate = startDate;
             }
 
             this._highlightRange(startDate, endDate);
@@ -546,7 +547,8 @@
                 startDate = this.getStartDate();
 
             if(moment(startDate).diff(endDate) > 0){
-                this.startCalendar.updateSelectedDate(endDate);
+                this.startCalendar.updateSelectedDate(endDate, {silent: true});
+                startDate = endDate;
             }
 
             this._highlightRange(startDate, endDate);

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -662,6 +662,56 @@ define(['lib/daterangepicker/daterangepicker'],
                     expect(spy.args[0][0].endDate.toString()).toEqual(moment([2012,11,30]).toString());
                 });
 
+                it('triggers endDateSelected with corrected date when end date before start date', function(){
+                    var spy = sinon.spy();
+
+                    picker.bind('endDateSelected', spy);
+
+                    picker.endCalendar.$el.find('.day[data-date="2012-12-20"]').click();
+
+                    expect(spy.calledOnce).toEqual(true);
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment([2012,11,20]).toString());
+                    expect(spy.args[0][0].endDate.toString()).toEqual(moment([2012,11,20]).toString());
+                });
+
+                it('triggers startDateSelected with corrected date when start date after end date', function(){
+                    var spy = sinon.spy();
+
+                    picker.endCalendar.$el.find('.day[data-date="2012-12-30"]').click();
+
+                    picker.bind('startDateSelected', spy);
+
+                    picker.startCalendar.$el.find('.day[data-date="2012-12-31"]').click();
+
+                    expect(spy.calledOnce).toEqual(true);
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment([2012,11,31]).toString());
+                    expect(spy.args[0][0].endDate.toString()).toEqual(moment([2012,11,31]).toString());
+                });
+
+                it('does not trigger onDateSelected on the other calendar when fixing start date', function(){
+                    var dateSelectedEventStub = sinon.stub();
+
+                    picker.startCalendar.$el.find('.day[data-date="2012-12-31"]').click();
+
+                    picker.startCalendar.bind('onDateSelected', dateSelectedEventStub);
+
+                    picker.endCalendar.$el.find('.day[data-date="2012-12-30"]').click();
+
+                    expect(dateSelectedEventStub.callCount).toEqual(0);
+                });
+
+                it('does not trigger onDateSelected on the other calendar when fixing end date', function(){
+                    var dateSelectedEventStub = sinon.stub();
+
+                    picker.endCalendar.$el.find('.day[data-date="2012-12-30"]').click();
+
+                    picker.endCalendar.bind('onDateSelected', dateSelectedEventStub);
+
+                    picker.startCalendar.$el.find('.day[data-date="2012-12-31"]').click();
+
+                    expect(dateSelectedEventStub.callCount).toEqual(0);
+                });
+
                 it('hides picker when done button is clicked', function(){
                     var hideSpy = sinon.spy(picker, 'hide');
                     picker.$el.find('button.done').click();


### PR DESCRIPTION
When the user clicks a end date > start date or start date > end date,
the other date is automatically set to the same date.
Now the "startDateSelected" and "endDateSelected" events are now sending
updated dates.

Also, the extra "onDateSelected" event is prevented for the date that's
getting fixed, as this one is passed through by the other events
already.
