### PR TITLE
Fix missing calendar row for months that start on Saturday (31 days) or Sunday (30 days)

### DIFF
--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -152,6 +152,7 @@
             var rowStartDate = this._getStartDate().subtract('days', 1),
                 selectedDate = this.selectedDate,
                 monthToDisplayIndex = this.monthToDisplay.month(),
+                lastDayOfMonthToDisplay = this.monthToDisplay.clone().add('months', 1).subtract('days', 1),
                 getClassName = function(date){
                     var classes = [];
 
@@ -165,7 +166,7 @@
                         return classes.join(' ');
                     }
                 },
-                weeksToShow = this._getStartDate().add('weeks', 6).month() > monthToDisplayIndex ? 5 : 6,
+                weeksToShow = Math.ceil(lastDayOfMonthToDisplay.diff(rowStartDate, 'days')/7),
                 data = {
                     label: this.label ? '<span class="calendar-label">' + this.label + '</span>' : '',
                     monthTitle: this.monthToDisplay.format('MMMM YYYY'),

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -66,6 +66,22 @@ define(['lib/daterangepicker/daterangepicker'],
                     expect(calendar.$el.find('tr.week').length).toEqual(6);
                 });
 
+                it('renders the table with 6 "week" rows for months with 30 days that start on a Sunday', function(){
+                    calendar = picker._createCalendar({
+                        selectedDate: '2013-09-30',
+                    });
+                    calendar.render();
+                    expect(calendar.$el.find('tr.week').length).toEqual(6);
+                });
+
+                it('renders the table with 6 "week" rows for months with 31 days that start on a Saturday', function(){
+                    calendar = picker._createCalendar({
+                        selectedDate: '2011-10-31',
+                    });
+                    calendar.render();
+                    expect(calendar.$el.find('tr.week').length).toEqual(6);
+                });
+
                 it('renders the table with 42 "day" cells', function(){
                     expect(calendar.$el.find('td.day').length).toEqual(42);
                 });


### PR DESCRIPTION
Currently, when a month has 31 days and starts on a Saturday or when it has 30 days and starts on a Sunday (and that month is _not_ December) then the calendar will be missing a table row (e.g. the issue occurs for January '12, April '12, July '12, September '13, etc.).

@grahamscott - Please review.
