### PR TITLE
Add bower to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mocha": "~1.7.4",
     "phantomjs": "^1.9.10",
     "serve": "*",
-    "testem": "^0.6.20"
+    "testem": "^0.6.20",
+    "bower": "^1.3.12"
   },
   "optionalDependencies": {},
   "volo": {


### PR DESCRIPTION
This relates to the change here: 7bbccd5c4fc12c67f1be0e043c0ba36ba26497fd
CI on Jenkins needs a local version of bower for the npm postinstall script
