### PR TITLE
Add timezone support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "expectations": "~0.2.6",
     "requirejs": ">=2",
     "mocha": ">=1.20.1",
-    "bootstrap": "2.1.1",
-    "sinon": ">=1.7.3"
+    "bootstrap": "2.1.1"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,6 +54,7 @@
                     $('#date4').daterangepicker({
                         startDate: moment().subtract({'h': 1}),
                         endDate: moment(),
+                        timezone: moment().format('UTCZ'),
                         plugins: [daterangepicker.timeSupport],
                         presets: {
                             '1hr': {

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -341,6 +341,8 @@
         $el.on('click', '.close a, .done', _.bind(this.onCloseClick, this));
         $el.on('click', 'table,div', function(e){ e.stopPropagation(); });
 
+        this.timezone = options.timezone;
+
         this.startCalendar = this._createCalendar({
             selectedDate: options.startDate,
             className: 'startCalendar',
@@ -439,10 +441,27 @@
             }
 
             lis = _(presets).map(function(val, key){
-                return '<li data-startdate="' + val.startDate + '" data-enddate="' + (val.endDate || val.startDate) +'" data-time="' + ((val.specifyTime) ? 'true' : 'false') + '">' + key + '</li>';
+                return [
+                    '<li',
+                        'data-startdate="' + val.startDate + '"',
+                        'data-enddate="' + (val.endDate || val.startDate) + '"',
+                        'data-time="' + ((val.specifyTime) ? 'true' : 'false') + '">' +
+                        key +
+                    '</li>'
+                ].join(' ');
             });
 
-            return '<div class="presets-wrapper"><div class="close"><a class="' + _.escape(this.closeButtonCssClass) + '"></a></div><nav class="presets"><h1>Quick Select</h1><ul>' + lis.join('') + '</ul></nav></div>';
+            return [
+                '<div class="presets-wrapper">',
+                    '<div class="close">',
+                        '<a class="' + _.escape(this.closeButtonCssClass) + '"></a>',
+                    '</div>',
+                    '<nav class="presets">',
+                        '<h1>Quick Select</h1>',
+                        '<ul>' + lis.join('') + '</ul>',
+                    '</nav>',
+                '</div>'
+            ].join(' ');
         },
 
         render: function(){

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -13,10 +13,6 @@
     var TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/,
         TIME_FORMAT = 'HH:mm';
 
-    function isValidTime(time) {
-        return TIME_REGEX.exec(time);
-    }
-
     function setupTimePanelEvents(panel) {
         panel.$el.on('change.time-panel', panel.$input, function() {
             if (panel.isValidTime()) {

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -208,7 +208,8 @@
         attach: function(daterangepicker) {
             var plugin = this,
                 startCalendar = daterangepicker.startCalendar,
-                endCalendar = daterangepicker.endCalendar;
+                endCalendar = daterangepicker.endCalendar,
+                timezone = daterangepicker.timezone;
 
             plugin.picker = daterangepicker;
 
@@ -224,7 +225,7 @@
                 });
 
                 $('<label class="time-support__to">To</label>').insertBefore(plugin.endPanel.$input);
-                $('<span class="time-support__zone">(UTC)</span>').insertAfter(plugin.endPanel.$input);
+                $('<span class="time-support__zone">(' + timezone + ')</span>').insertAfter(plugin.endPanel.$input);
             }
 
             daterangepicker.bind('onRendered', function() {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "sinon": ">=1.7.3",
     "mocha": "~1.7.4",
     "phantomjs": "^1.9.10",
     "serve": "*",

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -1,10 +1,13 @@
 define([
     'sinon',
+    'moment',
     'lib/daterangepicker/daterangepicker'
-], function(sinon, daterangepicker){
+], function(
+    sinon,
+    moment,
+    daterangepicker
+){
     'use strict';
-
-    var DateRangePicker = daterangepicker.DateRangePicker;
 
     describe('daterangepicker', function(){
         var picker,
@@ -488,7 +491,7 @@ define([
 
                 it('passes specifyTime as true if set to true on the preset', function() {
                     var spy = sinon.spy(),
-                        nye2012Str = moment([2012,11,31]);
+                        nye2012Str = moment.utc([2012,11,31]);
 
                     picker.bind('presetSelected', spy);
 
@@ -502,7 +505,7 @@ define([
 
                 it('passes specifyTime as false if set to false on the preset', function() {
                     var spy = sinon.spy(),
-                        christmas2012 = moment([2012,11,25]);
+                        christmas2012 = moment.utc([2012,11,25]);
 
                     picker.bind('presetSelected', spy);
 

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -1,11 +1,15 @@
 define([
     'sinon',
+    'moment',
     'lib/daterangepicker/daterangepicker',
     'lib/daterangepicker/daterangepicker.timesupport'
-], function(sinon, daterangepicker, timesupport) {
+], function(
+    sinon,
+    moment,
+    daterangepicker,
+    timesupport
+) {
     'use strict';
-
-    var DateRangePicker = daterangepicker.DateRangePicker;
 
     describe('time support plugin', function() {
         var picker,
@@ -49,11 +53,11 @@ define([
         describe('plugin options', function() {
             describe('when specifyTimeChecked is true', function() {
                 beforeEach(function() {
-                    sandbox.useFakeTimers(new Date(Date.UTC(2013, 7, 1, 11, 0)).getTime());
+                    sandbox.useFakeTimers(Date.UTC(2013, 7, 1, 11, 0));
 
                     picker = daterangepicker.create({
-                        startDate: moment().zone(120).toISOString(),
-                        endDate: moment().zone(120).add({'h': 2}).toISOString(),
+                        startDate: moment().utcOffset(120).toISOString(),
+                        endDate: moment().utcOffset(120).add({'h': 2}).toISOString(),
                         plugins: [timesupport],
                         timeSupport: {
                             specifyTimeChecked: true
@@ -118,8 +122,28 @@ define([
 
         describe('isValidTime', function() {
             var i,
-                validTimes = ['00:00', '10:20', '02:30'],
-                invalidTimes = ['0000', '   10:20', '12:  23', '2:30', '23 : 45', '10:20   ', '24:00', '23:59:59', '', '  ', '23:1d', '23::00', '2pm', '12am', '0'];
+                validTimes = [
+                    '00:00',
+                    '10:20',
+                    '02:30'
+                ],
+                invalidTimes = [
+                    '0000',
+                    '   10:20',
+                    '12:  23',
+                    '2:30',
+                    '23 : 45',
+                    '10:20   ',
+                    '24:00',
+                    '23:59:59',
+                    '',
+                    '  ',
+                    '23:1d',
+                    '23::00',
+                    '2pm',
+                    '12am',
+                    '0'
+                ];
 
             beforeEach(function() {
                 picker = daterangepicker.create({

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -13,6 +13,7 @@ define([
 
     describe('time support plugin', function() {
         var picker,
+            timezone = moment().format('UTCZ'),
             sandbox;
 
         beforeEach(function() {
@@ -31,6 +32,7 @@ define([
         describe('when attached', function() {
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    timezone: timezone,
                     plugins: [timesupport]
                 });
 
@@ -43,6 +45,11 @@ define([
 
             it('renders a checkbox to allow the use to specify a time', function() {
                 expect(picker.$el.find('[name="specifyTime"]').length).toEqual(1);
+            });
+
+            it('renders the relevant timezone inside a span', function() {
+                expect(picker.$el.find('.time-support__zone').length).toEqual(1);
+                expect(picker.$el.find('.time-support__zone').text()).toEqual('(' + timezone + ')');
             });
 
             it('renders two panels inside the wrapper', function() {

--- a/test/index.html
+++ b/test/index.html
@@ -40,7 +40,7 @@
                 'underscore': 'vendor/underscore/underscore',
                 'moment': 'vendor/moment/moment',
                 'timepicker': 'vendor/timepicker/lib/timepicker/timepicker',
-                'sinon': 'vendor/sinon/lib/sinon'
+                'sinon': 'node_modules/sinon/pkg/sinon'
             },
             shim: {
                 'underscore': {


### PR DESCRIPTION
Despite the build passing on Travis unit tests were failing when run locally and needed some fixes:

- SinonJS is now imported via npm instead of bower
- Moment.js is included on top of the test files as it was not defined before
- use `moment.utc()` to create test dates instead of `moment()`, so tests can be run in different timezones...

Daterangepicker now accepts a timezone attribute passed via options,
which is displayed next to the time selection boxes.

Includes some formatting and small refactoring.