### PR TITLE
Add ability to change timezone after picker has been rendered

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,12 +11,13 @@
     "timepicker": "git://github.com/BrandwatchLtd/timepicker.git#0.1.1",
     "jquery": "^1.7.2",
     "underscore": "^1.6.0",
-    "moment": ">=2.5.0"
+    "moment": ">=2.6.0"
   },
   "devDependencies": {
     "expectations": "~0.2.6",
     "requirejs": ">=2",
     "mocha": ">=1.20.1",
+    "moment-timezone": ">=0.3.0",
     "bootstrap": "2.1.1"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -43,6 +43,19 @@
                 </script>
             </div>
 
+            <div id="singleDate" class="demo">
+                <h2>Single date</h2>
+                <p>A datepicker instantiated with just one date</p>
+                <input id="date5">
+                <div id="picker5"></div>
+
+                <script>
+                    $('#date5').daterangepicker({
+                        singleDate: true
+                    });
+                </script>
+            </div>
+
             <div id="timeSupport" class="demo">
                 <h2>Time Support</h2>
                 <p>A datepicker instantiated with the time support plugin which allows you to specify time</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,6 @@
                 yesterday = today.clone().subtract('days', 1),
                 yesterdayStr = yesterday.format('YYYY-MM-DD'),
                 sevenDaysAgoStr = today.clone().subtract('days', 6).format('YYYY-MM-DD');
-
         </script>
     </head>
     <body>
@@ -36,8 +35,8 @@
             <div id="simple" class="demo">
                 <h2>Simple</h2>
                 <p>A datepicker instantiated with no options</p>
-                <input id="date1"></input>
-                <div id="picker1"/>
+                <input id="date1">
+                <div id="picker1"></div>
 
                 <script>
                     $('#date1').daterangepicker();
@@ -47,8 +46,8 @@
             <div id="timeSupport" class="demo">
                 <h2>Time Support</h2>
                 <p>A datepicker instantiated with the time support plugin which allows you to specify time</p>
-                <input id="date4"></input>
-                <div id="picker4"/>
+                <input id="date4">
+                <div id="picker4"></div>
 
                 <script>
                     $('#date4').daterangepicker({
@@ -97,12 +96,11 @@
                 </script>
             </div>
 
-
             <div id="presetRange" class="demo">
                 <h2>Preset Date Range</h2>
                 <p>A datepicker instantiated with a start and end date</p>
-                <input id="date2"></input>
-                <div id="picker2"/>
+                <input id="date2">
+                <div id="picker2"></div>
 
                 <script>
                     $('#date2').daterangepicker({
@@ -115,8 +113,8 @@
             <div id="datePresets" class="demo">
                 <h2>Preset Dates</h2>
                 <p>A datepicker instantiated with a list of preset date ranges</p>
-                <input id="date3"></input>
-                <div id="picker3"/>
+                <input id="date3">
+                <div id="picker3"></div>
 
                 <script>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
         <script src="/vendor/jquery/dist/jquery.js"></script>
         <script src="/vendor/underscore/underscore.js"></script>
         <script src="/vendor/moment/moment.js"></script>
+        <script src="/vendor/moment-timezone/builds/moment-timezone-with-data.js"></script>
         <script src="/vendor/timepicker/lib/timepicker/timepicker.js"></script>
         <script src="/lib/daterangepicker/daterangepicker.js"></script>
         <script src="/lib/daterangepicker/daterangepicker.timesupport.js"></script>
@@ -17,6 +18,10 @@
         <style>
             .demo {
                 margin:40px 0;
+            }
+
+            select {
+                margin-bottom: 0px;
             }
         </style>
 
@@ -60,13 +65,19 @@
                 <h2>Time Support</h2>
                 <p>A datepicker instantiated with the time support plugin which allows you to specify time</p>
                 <input id="date4">
+                <select id="picker4_timezone" title="Select a value to to change the displayed timezone via setTimezone()"></select>
                 <div id="picker4"></div>
 
                 <script>
-                    $('#date4').daterangepicker({
+                    var $input = $('#date4'),
+                        $timezonePicker,
+                        $daterangepicker,
+                        initialTimezone = moment.tz.names()[0];
+
+                    $input.daterangepicker({
                         startDate: moment().subtract({'h': 1}),
                         endDate: moment(),
-                        timezone: moment().format('UTCZ'),
+                        timezone: initialTimezone,
                         plugins: [daterangepicker.timeSupport],
                         presets: {
                             '1hr': {
@@ -105,6 +116,18 @@
                                 return startDate.format('DD MMM YYYY') + ' - ' + endDate.format('DD MMM YYYY');
                             }
                         }
+                    });
+
+                    $timezoneSelect = $('#picker4_timezone');
+                    $daterangepicker = $input.data('picker');
+
+                    moment.tz.names().forEach(function(name){
+                        $('<option/>').text(name).val(name).appendTo($timezoneSelect);
+                    });
+
+                    $timezoneSelect.val(initialTimezone);
+                    $timezoneSelect.change(function() {
+                        $daterangepicker.timeSupport.setTimezone(this.value);
                     });
                 </script>
             </div>

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -128,10 +128,8 @@
             plugin.startPanel.updateCalendarDate({silent: true});
             refreshData.startDate = plugin.startPanel.calendar.selectedDate;
 
-            if (plugin.endPanel){
-                plugin.endPanel.updateCalendarDate({silent: true});
-                refreshData.endDate = plugin.endPanel.calendar.selectedDate;
-            }
+            plugin.endPanel.updateCalendarDate({silent: true});
+            refreshData.endDate = plugin.endPanel.calendar.selectedDate;
 
             plugin.picker.trigger('refresh', refreshData);
         },
@@ -155,9 +153,7 @@
 
             plugin.$panelWrapper.html(plugin.startPanel.$el);
 
-            if (plugin.endPanel) {
-                plugin.$panelWrapper.append(plugin.endPanel.$el);
-            }
+            plugin.$panelWrapper.append(plugin.endPanel.$el);
 
             plugin.setPanelState();
         },
@@ -175,19 +171,16 @@
         },
 
         getEndTimePicker: function () {
-            if (this.endPanel){
-                return this.endPanel.$input.data('timepicker');
-            }
+            return this.endPanel.$input.data('timepicker');
         },
 
         openPanel: function() {
-            var plugin = this;
+            this.$panelWrapper.addClass('isOpen');
 
-            plugin.$panelWrapper.addClass('isOpen');
+            this.updateStartTime(this.startPanel.calendar.selectedDate.utc());
+            this.updateEndTime(this.endPanel.calendar.selectedDate.utc());
 
-            plugin.updateStartTime(plugin.startPanel.calendar.selectedDate.utc());
-            plugin.updateEndTime(plugin.endPanel.calendar.selectedDate.utc());
-            plugin.resetCalendars();
+            this.resetCalendars();
         },
 
         closePanel: function() {
@@ -198,9 +191,7 @@
 
             plugin.updateStartTime(startOfDay);
 
-            if (plugin.endPanel){
-                plugin.updateEndTime(startOfDay);
-            }
+            plugin.updateEndTime(startOfDay);
 
             plugin.resetCalendars();
         },
@@ -211,6 +202,10 @@
                 endCalendar = daterangepicker.endCalendar,
                 timezone = daterangepicker.timezone ? daterangepicker.timezone : 'UTC';
 
+            if (!endCalendar) {
+                throw new Error('Timepicker is not supported for single date');
+            }
+
             plugin.picker = daterangepicker;
 
             plugin.startPanel = new TimePanel({
@@ -219,14 +214,12 @@
 
             $('<label class="time-support__from">From</label>').insertBefore(plugin.startPanel.$input);
 
-            if (endCalendar) {
-                plugin.endPanel = new TimePanel({
-                    calendar: endCalendar
-                });
+            plugin.endPanel = new TimePanel({
+                calendar: endCalendar
+            });
 
-                $('<label class="time-support__to">To</label>').insertBefore(plugin.endPanel.$input);
-                $('<span class="time-support__zone">(' + timezone + ')</span>').insertAfter(plugin.endPanel.$input);
-            }
+            $('<label class="time-support__to">To</label>').insertBefore(plugin.endPanel.$input);
+            $('<span class="time-support__zone">(' + timezone + ')</span>').insertAfter(plugin.endPanel.$input);
 
             daterangepicker.bind('onRendered', function() {
                 plugin.render(daterangepicker);
@@ -247,7 +240,6 @@
                     silent: true
                 });
             });
-
 
             daterangepicker.bind('presetSelected', function(args) {
                 var specifyTime = (args.specifyTime === true);
@@ -288,11 +280,9 @@
                 updateSelectedDateWrapper(plugin.startPanel, originalFunc, date, options);
             });
 
-            if (endCalendar) {
-                endCalendar.updateSelectedDate = _.wrap(endCalendar.updateSelectedDate, function(originalFunc, date, options) {
-                    updateSelectedDateWrapper(plugin.endPanel, originalFunc, date, options);
-                });
-            }
+            endCalendar.updateSelectedDate = _.wrap(endCalendar.updateSelectedDate, function(originalFunc, date, options) {
+                updateSelectedDateWrapper(plugin.endPanel, originalFunc, date, options);
+            });
         },
 
         detach: function() {
@@ -302,9 +292,7 @@
 
             plugin.startPanel.destroy();
 
-            if (plugin.endPanel) {
-                plugin.endPanel.destroy();
-            }
+            plugin.endPanel.destroy();
         }
     });
 

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -11,7 +11,8 @@
     'use strict';
 
     var TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/,
-        TIME_FORMAT = 'HH:mm';
+        TIME_FORMAT = 'HH:mm',
+        DEFAULT_TIMEZONE = 'UTC';
 
     function setupTimePanelEvents(panel) {
         panel.$el.on('change.time-panel', panel.$input, function() {
@@ -170,6 +171,10 @@
             return this.startPanel.$input.data('timepicker');
         },
 
+        setTimezone: function(timezone) {
+            this.$timezoneSpan.text('(' + timezone + ')');
+        },
+
         getEndTimePicker: function () {
             return this.endPanel.$input.data('timepicker');
         },
@@ -200,7 +205,7 @@
             var plugin = this,
                 startCalendar = daterangepicker.startCalendar,
                 endCalendar = daterangepicker.endCalendar,
-                timezone = daterangepicker.timezone ? daterangepicker.timezone : 'UTC';
+                timezone = daterangepicker.timezone || DEFAULT_TIMEZONE;
 
             if (!endCalendar) {
                 throw new Error('Timepicker is not supported for single date');
@@ -219,7 +224,9 @@
             });
 
             $('<label class="time-support__to">To</label>').insertBefore(plugin.endPanel.$input);
-            $('<span class="time-support__zone">(' + timezone + ')</span>').insertAfter(plugin.endPanel.$input);
+            this.$timezoneSpan = $('<span class="time-support__zone"></span>').insertAfter(plugin.endPanel.$input);
+
+            this.setTimezone(timezone);
 
             daterangepicker.bind('onRendered', function() {
                 plugin.render(daterangepicker);

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -28,6 +28,17 @@ define([
             }
         });
 
+        describe('instantiation', function() {
+            it('throws if used on a "single date" picker', function() {
+                expect(function(){
+                    daterangepicker.create({
+                        singleDate: true,
+                        plugins: [timesupport]
+                    });
+                }).toThrow();
+            });
+        });
+
         describe('when attached', function() {
             beforeEach(function() {
                 picker = daterangepicker.create({
@@ -301,50 +312,31 @@ define([
             });
         });
 
-        describe('get time picker methods', function () {
-            describe('for date range pickers', function () {
-                beforeEach(function() {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport]
-                    });
-
-                    picker.render();
+        describe('getStartTimePicker', function () {
+            beforeEach(function() {
+                picker = daterangepicker.create({
+                    plugins: [timesupport]
                 });
 
-                describe('getStartTimePicker', function () {
-                    it('returns the time picker for the start panel', function () {
-                        expect(picker.timeSupport.getStartTimePicker()).toEqual(picker.timeSupport.startPanel.$input.data('timepicker'));
-                    });
-                });
-
-                describe('getEndTimePicker', function () {
-                    it('returns the time picker for the end panel', function () {
-                        expect(picker.timeSupport.getEndTimePicker()).toEqual(picker.timeSupport.endPanel.$input.data('timepicker'));
-                    });
-                });
+                picker.render();
             });
 
-            describe('for single date pickers', function () {
-                beforeEach(function() {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport],
-                        singleDate: true
-                    });
+            it('returns the time picker for the start panel', function () {
+                expect(picker.timeSupport.getStartTimePicker()).toEqual(picker.timeSupport.startPanel.$input.data('timepicker'));
+            });
+        });
 
-                    picker.render();
+        describe('getEndTimePicker', function () {
+            beforeEach(function() {
+                picker = daterangepicker.create({
+                    plugins: [timesupport]
                 });
 
-                describe('getStartTimePicker', function () {
-                    it('returns the time picker for the start panel', function () {
-                        expect(picker.timeSupport.getStartTimePicker()).toEqual(picker.timeSupport.startPanel.$input.data('timepicker'));
-                    });
-                });
+                picker.render();
+            });
 
-                describe('getEndTimePicker', function () {
-                    it('returns undefined', function () {
-                        expect(picker.timeSupport.getEndTimePicker()).not.toBeDefined();
-                    });
-                });
+            it('returns the time picker for the end panel', function () {
+                expect(picker.timeSupport.getEndTimePicker()).toEqual(picker.timeSupport.endPanel.$input.data('timepicker'));
             });
         });
 
@@ -489,101 +481,55 @@ define([
         describe('refreshCalendars', function () {
             var refreshSpy;
 
-            describe('with a start and end calendar', function () {
-                beforeEach(function () {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport]
-                    });
-
-                    picker.render();
-
-                    refreshSpy = sandbox.spy();
-
-                    picker.bind('refresh', refreshSpy);
-
-                    picker.timeSupport.resetCalendars();
+            beforeEach(function () {
+                picker = daterangepicker.create({
+                    plugins: [timesupport]
                 });
 
-                it('triggers a "refresh" event', function () {
-                    expect(refreshSpy.calledOnce).toEqual(true);
-                });
+                picker.render();
 
-                it('provides startDate and endDate as event data', function () {
-                    expect(Object.keys(refreshSpy.args[0][0])).toEqual(['startDate', 'endDate']);
-                });
+                refreshSpy = sandbox.spy();
+
+                picker.bind('refresh', refreshSpy);
+
+                picker.timeSupport.resetCalendars();
             });
 
-            describe('in singleDate mode', function () {
-                beforeEach(function () {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport],
-                        singleDate: true
-                    });
+            it('triggers a "refresh" event', function () {
+                expect(refreshSpy.calledOnce).toEqual(true);
+            });
 
-                    picker.render();
-
-                    refreshSpy = sandbox.spy();
-
-                    picker.bind('refresh', refreshSpy);
-
-                    picker.timeSupport.resetCalendars();
-                });
-
-                it('only provides startDate event data', function () {
-                    expect(Object.keys(refreshSpy.args[0][0])).toEqual(['startDate']);
-                });
+            it('provides startDate and endDate as event data', function () {
+                expect(Object.keys(refreshSpy.args[0][0])).toEqual(['startDate', 'endDate']);
             });
         });
 
         describe('closePanel', function () {
-            describe('with a start and end calendar', function () {
-                beforeEach(function () {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport]
-                    });
-
-                    picker.render();
-
-                    sandbox.spy(picker.timeSupport, 'updateStartTime');
-                    sandbox.spy(picker.timeSupport, 'updateEndTime');
-
-                    picker.timeSupport.closePanel();
+            beforeEach(function () {
+                picker = daterangepicker.create({
+                    plugins: [timesupport]
                 });
 
-                it('removes the "isOpen" class from the panel', function () {
-                    expect(picker.timeSupport.$panelWrapper.hasClass('isOpen')).toEqual(false);
-                });
+                picker.render();
 
-                it('calls updateStartTime', function () {
-                    expect(picker.timeSupport.updateStartTime.calledOnce).toEqual(true);
-                });
+                sandbox.spy(picker.timeSupport, 'updateStartTime');
+                sandbox.spy(picker.timeSupport, 'updateEndTime');
 
-                it('calls updateEndTime', function () {
-                    expect(picker.timeSupport.updateEndTime.calledOnce).toEqual(true);
-                });
+                picker.timeSupport.closePanel();
             });
 
-            describe('in singleDate mode', function () {
-                beforeEach(function () {
-                    picker = daterangepicker.create({
-                        plugins: [timesupport],
-                        singleDate: true
-                    });
+            it('removes the "isOpen" class from the panel', function () {
+                expect(picker.timeSupport.$panelWrapper.hasClass('isOpen')).toEqual(false);
+            });
 
-                    picker.render();
+            it('calls updateStartTime', function () {
+                expect(picker.timeSupport.updateStartTime.calledOnce).toEqual(true);
+            });
 
-                    sandbox.spy(picker.timeSupport, 'updateStartTime');
-                    sandbox.spy(picker.timeSupport, 'updateEndTime');
-
-                    picker.timeSupport.closePanel();
-                });
-
-                it('does not call updateEndTime', function () {
-                    expect(picker.timeSupport.updateEndTime.called).toEqual(false);
-                });
+            it('calls updateEndTime', function () {
+                expect(picker.timeSupport.updateEndTime.calledOnce).toEqual(true);
             });
         });
-
 
         describe('as a jquery plugin', function() {
             var input,

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -312,31 +312,36 @@ define([
             });
         });
 
-        describe('getStartTimePicker', function () {
+        describe('TimeSupport prototype methods', function() {
+            var timeSupport;
+
             beforeEach(function() {
                 picker = daterangepicker.create({
                     plugins: [timesupport]
                 });
 
+                timeSupport = picker.timeSupport;
                 picker.render();
             });
 
-            it('returns the time picker for the start panel', function () {
-                expect(picker.timeSupport.getStartTimePicker()).toEqual(picker.timeSupport.startPanel.$input.data('timepicker'));
-            });
-        });
-
-        describe('getEndTimePicker', function () {
-            beforeEach(function() {
-                picker = daterangepicker.create({
-                    plugins: [timesupport]
+            describe('getStartTimePicker', function () {
+                it('returns the time picker for the start panel', function () {
+                    expect(picker.timeSupport.getStartTimePicker()).toEqual(picker.timeSupport.startPanel.$input.data('timepicker'));
                 });
-
-                picker.render();
             });
 
-            it('returns the time picker for the end panel', function () {
-                expect(picker.timeSupport.getEndTimePicker()).toEqual(picker.timeSupport.endPanel.$input.data('timepicker'));
+            describe('getEndTimePicker', function () {
+                it('returns the time picker for the end panel', function () {
+                    expect(picker.timeSupport.getEndTimePicker()).toEqual(picker.timeSupport.endPanel.$input.data('timepicker'));
+                });
+            });
+
+            describe('setTimezone', function () {
+                it('changes the timezone displayed in the timepicker', function () {
+                    expect(timeSupport.$timezoneSpan.text()).toEqual('(UTC)');
+                    timeSupport.setTimezone('Europe/Helsinki');
+                    expect(timeSupport.$timezoneSpan.text()).toEqual('(Europe/Helsinki)');
+                });
             });
         });
 


### PR DESCRIPTION
This is done by calling `$daterangepicker.timeSupport.setTimezone()` - as shown in the example added on the demo page. A missing example for `singleDate: true` pickers was also added, and timepicker support for those was removed as it broken and impractical.
More information in individual commits.