### PR TITLE
Add timezone support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,13 +11,13 @@
     "timepicker": "git://github.com/BrandwatchLtd/timepicker.git#0.1.1",
     "jquery": "^1.7.2",
     "underscore": "^1.6.0",
-    "moment": ">=2.6.0"
+    "moment": ">=2.6.0",
+    "moment-timezone": ">=0.3.0"
   },
   "devDependencies": {
     "expectations": "~0.2.6",
     "requirejs": ">=2",
     "mocha": ">=1.20.1",
-    "moment-timezone": ">=0.3.0",
     "bootstrap": "2.1.1"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,11 @@
             select {
                 margin-bottom: 0px;
             }
+
+            #date4-utc {
+                height: 20px;
+                margin-top: 12px;
+            }
         </style>
 
         <script>
@@ -66,68 +71,87 @@
                 <p>A datepicker instantiated with the time support plugin which allows you to specify time</p>
                 <input id="date4">
                 <select id="picker4_timezone" title="Select a value to to change the displayed timezone via setTimezone()"></select>
+                <div id="date4-utc"></div>
                 <div id="picker4"></div>
 
                 <script>
-                    var $input = $('#date4'),
-                        $timezonePicker,
-                        $daterangepicker,
-                        initialTimezone = moment.tz.names()[0];
+                    var $input4 = $('#date4');
+                    var $utcRangeEl = $('#date4-utc');
+                    var $daterangepicker;
+                    var $timezoneSelect;
+                    var initialTimezone = 'Etc/UTC';
 
-                    $input.daterangepicker({
-                        startDate: moment().subtract({'h': 1}),
-                        endDate: moment(),
-                        timezone: initialTimezone,
-                        plugins: [daterangepicker.timeSupport],
-                        presets: {
-                            '1hr': {
-                                startDate: today.clone().subtract('hours', 1).format('YYYY-MM-DDTHH:mm'),
-                                endDate: today.format('YYYY-MM-DDTHH:mm'),
-                                specifyTime: true
-                            },
-                            '6hr': {
-                                startDate: today.clone().subtract('hours', 6).format('YYYY-MM-DDTHH:mm'),
-                                endDate: today.format('YYYY-MM-DDTHH:mm'),
-                                specifyTime: true
-                            },
-                            today: {
-                                startDate: todayStr,
-                                endDate: todayStr
-                            },
-                            yesterday: {
-                                startDate: yesterdayStr,
-                                endDate: yesterdayStr
-                            },
-                            'last seven days': {
-                                startDate: sevenDaysAgoStr,
-                                endDate: todayStr
-                            }
-                        },
-                        timeSupport: {
-                            specifyTimeChecked: true
-                        },
-                        dateFormatter: function (startDate, endDate) {
-                            var picker = $('#date4').data('picker'),
-                                specifyTime = picker.$el.find('[name=specifyTime]').prop('checked');
+                    function buildDateRangePicker(options) {
+                        var timezone = options.timezone;
 
-                            if (specifyTime) {
-                                return startDate.format('DD MMM YYYY, HH:mm') + ' - ' + endDate.format('DD MMM YYYY, HH:mm');
-                            } else {
-                                return startDate.format('DD MMM YYYY') + ' - ' + endDate.format('DD MMM YYYY');
+                        $input4.daterangepicker({
+                            startDate: moment().subtract({'h': 1}),
+                            endDate: moment(),
+                            timezone: timezone,
+                            plugins: [daterangepicker.timeSupport],
+                            presets: {
+                                '1hr': {
+                                    startDate: today.clone().subtract('hours', 1).format('YYYY-MM-DDTHH:mm'),
+                                    endDate: today.format('YYYY-MM-DDTHH:mm'),
+                                    specifyTime: true
+                                },
+                                '6hr': {
+                                    startDate: today.clone().subtract('hours', 6).format('YYYY-MM-DDTHH:mm'),
+                                    endDate: today.format('YYYY-MM-DDTHH:mm'),
+                                    specifyTime: true
+                                },
+                                today: {
+                                    startDate: todayStr,
+                                    endDate: todayStr
+                                },
+                                yesterday: {
+                                    startDate: yesterdayStr,
+                                    endDate: yesterdayStr
+                                },
+                                'last seven days': {
+                                    startDate: sevenDaysAgoStr,
+                                    endDate: todayStr
+                                }
+                            },
+                            timeSupport: {
+                                specifyTimeChecked: true
+                            },
+                            dateFormatter: function (startDate, endDate) {
+                                var picker = $('#date4').data('picker');
+                                var specifyTime = picker.$el.find('[name=specifyTime]').prop('checked');
+                                var format = specifyTime ? 'DD MMM YYYY, HH:mm' : 'DD MMM YYYY';
+                                var rangeUTC = startDate.tz('Etc/UTC').format(format) + ' - ' + endDate.tz('Etc/UTC').format(format);
+
+                                $utcRangeEl.text(rangeUTC + ' (UTC)');
+
+                                if (specifyTime) {
+                                    return startDate.tz(timezone).format(format) + ' - ' + endDate.tz(timezone).format(format);
+                                } else {
+                                    return startDate.tz(timezone).format(format) + ' - ' + endDate.tz(timezone).format(format);
+                                }
                             }
-                        }
+                        });
+
+                        $daterangepicker = $input4.data('picker');
+                    }
+
+                    buildDateRangePicker({
+                        timezone: initialTimezone
                     });
 
                     $timezoneSelect = $('#picker4_timezone');
-                    $daterangepicker = $input.data('picker');
-
                     moment.tz.names().forEach(function(name){
                         $('<option/>').text(name).val(name).appendTo($timezoneSelect);
                     });
 
                     $timezoneSelect.val(initialTimezone);
                     $timezoneSelect.change(function() {
-                        $daterangepicker.timeSupport.setTimezone(this.value);
+                        $utcRangeEl.text('');
+                        $daterangepicker.destroy();
+                        $input4.val('');
+                        buildDateRangePicker({
+                            timezone: this.value
+                        });
                     });
                 </script>
             </div>

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -401,8 +401,8 @@
 
     _.extend(DateRangePicker.prototype, {
 
-        _createCalendar: function(month, year, selectedDate, className){
-            return new Calendar(month, year, selectedDate, className);
+        _createCalendar: function(options){
+            return new Calendar(options);
         },
 
         _updateStartCalendarHighlight: function(){

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -60,7 +60,7 @@
     // Work with AMD or plain-ol script tag
     if(typeof define === 'function' && define.amd){
         // If window.jQuery or window._ are not defined, then assume we're using AMD modules
-        define(['jquery', 'underscore', 'moment'], function($, _, moment){
+        define(['jquery', 'underscore', 'moment', 'moment-timezone'], function($, _, moment){
             return factory($ || root.jQuery, _ || root._, moment || root.moment, MicroEvent);
         });
     }else{

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -85,16 +85,16 @@
         DEFAULT_TIMEZONE = 'UTC';
 
     function Calendar(options){
-        var todayString = moment().format('YYYY-MM-DD');
+        var $el = this.$el = $('<div>');
+        var className = options.className;
+        var timezone = this.timezone = options.timezone;
+        var todayString = moment.tz(timezone).format('YYYY-MM-DD');
+        var selectedDate = this.selectedDate = moment.tz(options.selectedDate, timezone);
+        var monthToDisplay = moment.tz([selectedDate.year(), selectedDate.month()], timezone);
 
         options = _.defaults(options, {
             selectedDate: todayString
         });
-
-        var $el = this.$el = $('<div>'),
-            className = options.className,
-            selectedDate = this.selectedDate = moment.utc(options.selectedDate),
-            monthToDisplay = moment.utc([selectedDate.year(), selectedDate.month()]);
 
         this.label = options.label;
 
@@ -233,7 +233,7 @@
         updateSelectedDate: function(date, options){
             options = options || {};
 
-            var newDate = this.selectedDate = moment.utc(date),
+            var newDate = this.selectedDate = moment.tz(date, this.timezone),
                 month = newDate.month(),
                 year = newDate.year(),
                 monthToDisplay = this.monthToDisplay,
@@ -251,7 +251,7 @@
         },
 
         showMonth: function(year, month){
-            this.monthToDisplay = moment.utc([year, month, 1]);
+            this.monthToDisplay = moment.tz([year, month, 1], this.timezone);
             this.render();
 
             this.trigger('onMonthDisplayed', { month: this.monthToDisplay });
@@ -327,8 +327,8 @@
     });
 
     function DateRangePicker(options){
-        var todayString = moment().format('YYYY-MM-DD'),
-            $el = this.$el = $('<div/>');
+        var todayString;
+        var $el = this.$el = $('<div/>');
 
         options = _.defaults(options, {
             startDate: todayString,
@@ -338,6 +338,8 @@
         });
 
         this.timezone = options.timezone || DEFAULT_TIMEZONE;
+        todayString = moment.tz(this.timezone).format('YYYY-MM-DD');
+
         // required to catch "empty string" cases
         options.startDate = options.startDate || todayString;
         options.endDate = options.endDate || todayString;
@@ -352,6 +354,7 @@
 
         this.startCalendar = this._createCalendar({
             selectedDate: options.startDate,
+            timezone: this.timezone,
             className: 'startCalendar',
             label: options.singleDate?'':'From'
         });
@@ -359,6 +362,7 @@
         if (!options.singleDate){
             this.endCalendar = this._createCalendar({
                 selectedDate: options.endDate,
+                timezone: this.timezone,
                 className: 'endCalendar',
                 label: 'To'
             });
@@ -566,9 +570,9 @@
         },
 
         setDateRange: function(startDate, endDate){
-            startDate = moment.utc(startDate);
+            startDate = moment.tz(startDate, this.timezone);
             if (this.endCalendar){
-                endDate = moment.utc(endDate);
+                endDate = moment.tz(endDate, this.timezone);
                 if(startDate.diff(endDate) > 0){
                     return;
                 }
@@ -582,10 +586,10 @@
         },
 
         onStartDateSelected: function(args){
-            var startDate = moment.utc(args.date),
+            var startDate = moment.tz(args.date, this.timezone),
                 endDate = this.getEndDate();
 
-            if(moment.utc(startDate).diff(endDate) > 0){
+            if(moment.tz(startDate, this.timezone).diff(endDate) > 0){
                 this.endCalendar.updateSelectedDate(startDate, {silent: true});
                 endDate = startDate;
             }
@@ -599,10 +603,10 @@
         },
 
         onEndDateSelected: function(args){
-            var endDate = moment.utc(args.date),
+            var endDate = moment.tz(args.date, this.timezone),
                 startDate = this.getStartDate();
 
-            if(moment.utc(startDate).diff(endDate) > 0){
+            if(moment.tz(startDate, this.timezone).diff(endDate) > 0){
                 this.startCalendar.updateSelectedDate(endDate, {silent: true});
                 startDate = endDate;
             }
@@ -619,8 +623,8 @@
             e.stopPropagation();
 
             var target = $(e.target),
-                startDate = moment.utc(target.data('startdate')),
-                endDate = moment.utc(target.data('enddate')),
+                startDate = moment.tz(target.data('startdate'), this.timezone),
+                endDate = moment.tz(target.data('enddate'), this.timezone),
                 specifyTime = target.data('time');
 
             this.startCalendar.updateSelectedDate(startDate, { silent : true });

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -81,7 +81,8 @@
         throw new Error('daterangepicker requires moment to be loaded');
     }
 
-    var MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+    var MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24,
+        DEFAULT_TIMEZONE = 'UTC';
 
     function Calendar(options){
         var todayString = moment().format('YYYY-MM-DD');
@@ -336,6 +337,7 @@
             singleDate: false
         });
 
+        this.timezone = options.timezone || DEFAULT_TIMEZONE;
         // required to catch "empty string" cases
         options.startDate = options.startDate || todayString;
         options.endDate = options.endDate || todayString;
@@ -347,7 +349,6 @@
         $el.on('click', '.close a, .done', _.bind(this.onCloseClick, this));
         $el.on('click', 'table,div', function(e){ e.stopPropagation(); });
 
-        this.timezone = options.timezone;
 
         this.startCalendar = this._createCalendar({
             selectedDate: options.startDate,

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -140,7 +140,9 @@
             var startDate = this.monthToDisplay.clone();
 
             if(startDate.day() !== 1){
-                startDate.subtract('days', (startDate.day()||7) -1);
+                startDate.subtract({
+                    d: (startDate.day() || 7) - 1
+                });
             }
 
             return startDate;
@@ -151,10 +153,12 @@
         },
 
         render: function(){
-            var rowStartDate = this._getStartDate().subtract('days', 1),
+            var rowStartDate = this._getStartDate().subtract({
+                    d:1
+                }),
                 selectedDate = this.selectedDate,
                 monthToDisplayIndex = this.monthToDisplay.month(),
-                lastDayOfMonthToDisplay = this.monthToDisplay.clone().add('months', 1).subtract('days', 1),
+                lastDayOfMonthToDisplay = this.monthToDisplay.clone().add({M: 1}).subtract({d: 1}),
                 getClassName = function(date){
                     var classes = [];
 
@@ -175,7 +179,9 @@
                     rows: _.map(_.range(weeksToShow), function(weekIdx){
                         return {
                             columns: _.map(_.range(7), function(dayIdx){
-                                var date = rowStartDate.clone().add('days', (weekIdx * 7) + (dayIdx + 1) );
+                                var date = rowStartDate.clone().add({
+                                    d: (weekIdx * 7) + (dayIdx + 1)
+                                });
 
                                 return {
                                     date: date.format('YYYY-MM-DD'),
@@ -212,14 +218,14 @@
         onNextClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.clone().add('months', 1);
+            var monthToShow = this.monthToDisplay.clone().add({M: 1});
             this.showMonth(monthToShow.year(), monthToShow.month());
         },
 
         onPreviousClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.subtract('months', 1);
+            var monthToShow = this.monthToDisplay.subtract({M: 1});
             this.showMonth(monthToShow.year(), monthToShow.month());
         },
 

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -382,14 +382,15 @@
     }
 
     DateRangePicker.create = function(options){
-        var plugins, i;
-
         options = options || {};
+
+        var plugins;
+        var i;
+        var $input = options.$input;
+        var className = options.className;
+        var picker;
+
         plugins = (options && options.plugins) || [];
-
-
-        var className = options.className,
-            picker;
 
         delete options.className;
 
@@ -402,6 +403,9 @@
         if(className){
             picker.$el.addClass(className);
         }
+
+        picker.$input = $input;
+        $input.data('picker', picker);
 
         return picker;
     };
@@ -546,6 +550,7 @@
             }
             this._plugins = [];
 
+            this.$input.removeData('picker');
             this.$el.remove();
         },
 
@@ -683,16 +688,15 @@
                 boundUpdate = _.bind(updateValue, $self, formatter);
 
             if(!picker){
+                options.$input = $self;
                 picker = DateRangePicker.create(options);
-                picker.$input = $self;
+
                 picker.render();
 
                 picker.bind('startDateSelected', boundUpdate);
                 picker.bind('endDateSelected', boundUpdate);
                 picker.bind('presetSelected', boundUpdate);
                 picker.bind('refresh', boundUpdate);
-
-                $self.data('picker', picker);
 
                 $('body').append(picker.$el.hide());
             }

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -11,8 +11,7 @@
     'use strict';
 
     var TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/,
-        TIME_FORMAT = 'HH:mm',
-        DEFAULT_TIMEZONE = 'UTC';
+        TIME_FORMAT = 'HH:mm';
 
     function setupTimePanelEvents(panel) {
         panel.$el.on('change.time-panel', panel.$input, function() {
@@ -205,7 +204,7 @@
             var plugin = this,
                 startCalendar = daterangepicker.startCalendar,
                 endCalendar = daterangepicker.endCalendar,
-                timezone = daterangepicker.timezone || DEFAULT_TIMEZONE;
+                timezone = daterangepicker.timezone;
 
             if (!endCalendar) {
                 throw new Error('Timepicker is not supported for single date');

--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -41,6 +41,7 @@
         this.$el = getTimePanel();
         this.$input = this.$el.find('input[name="time"]').timepicker();
         this.calendar = options.calendar;
+        this.timezone = options.timezone;
 
         setupTimePanelEvents(this);
     }
@@ -62,7 +63,7 @@
 
         getTime: function() {
             var time = this.$input.val();
-            return moment.utc(time, TIME_FORMAT);
+            return moment.tz(time, TIME_FORMAT, this.timezone);
         },
 
         setTime: function(time) {
@@ -84,13 +85,13 @@
                 minutes = time.minutes();
             }
 
-            date = moment.utc([
+            date = moment.tz([
                 currentDate.year(),
                 currentDate.month(),
                 currentDate.date(),
                 hours,
                 minutes
-            ]);
+            ], this.timezone);
 
             panel.calendar.updateSelectedDate(date, options);
         },
@@ -158,12 +159,12 @@
             plugin.setPanelState();
         },
 
-        updateStartTime: function(time) {
-            this.startPanel.setTime(time.format(TIME_FORMAT));
+        updateStartTime: function(startMoment) {
+            this.startPanel.setTime(startMoment.format(TIME_FORMAT));
         },
 
-        updateEndTime: function(time) {
-            this.endPanel.setTime(time.format(TIME_FORMAT));
+        updateEndTime: function(endMoment) {
+            this.endPanel.setTime(endMoment.format(TIME_FORMAT));
         },
 
         getStartTimePicker: function () {
@@ -181,8 +182,8 @@
         openPanel: function() {
             this.$panelWrapper.addClass('isOpen');
 
-            this.updateStartTime(this.startPanel.calendar.selectedDate.utc());
-            this.updateEndTime(this.endPanel.calendar.selectedDate.utc());
+            this.updateStartTime(this.startPanel.calendar.selectedDate.tz(this.picker.timezone));
+            this.updateEndTime(this.endPanel.calendar.selectedDate.tz(this.picker.timezone));
 
             this.resetCalendars();
         },
@@ -213,13 +214,15 @@
             plugin.picker = daterangepicker;
 
             plugin.startPanel = new TimePanel({
-                calendar: startCalendar
+                calendar: startCalendar,
+                timezone: timezone
             });
 
             $('<label class="time-support__from">From</label>').insertBefore(plugin.startPanel.$input);
 
             plugin.endPanel = new TimePanel({
-                calendar: endCalendar
+                calendar: endCalendar,
+                timezone: timezone
             });
 
             $('<label class="time-support__to">To</label>').insertBefore(plugin.endPanel.$input);
@@ -276,7 +279,7 @@
 
                 if (plugin.$specifyTime.prop('checked')) {
                     time = panel.getTime();
-                    date = moment.utc(date).hours(time.hours()).minutes(time.minutes());
+                    date = moment.tz(date, timezone).hours(time.hours()).minutes(time.minutes());
                 }
 
                 originalUpdateSelectedDate.call(panel.calendar, date, options);

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -10,10 +10,10 @@ define([
     'use strict';
 
     describe('daterangepicker', function(){
-        var picker,
-            christmas2012Str = moment.utc([2012,11,25]).format('YYYY-MM-DD'),
-            nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
-
+        var picker;
+        var christmas2012Str = moment.utc([2012,11,25]).format('YYYY-MM-DD');
+        var nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
+        var $testInput = $('<input type="text">');
 
         afterEach(function(){
             if(picker){
@@ -26,7 +26,9 @@ define([
             var calendar;
 
             beforeEach(function(){
-                picker = daterangepicker.create();
+                picker = daterangepicker.create({
+                    $input: $testInput
+                });
                 calendar = picker._createCalendar({
                     selectedDate: '2012-12-25',
                     className: 'myCalendar'
@@ -115,6 +117,7 @@ define([
 
                 it('renders the close button when presets specified', function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         presets: {
                             'christmas 2012': {
                                 startDate: christmas2012Str
@@ -130,6 +133,7 @@ define([
 
                 it('renders the close button with custom css class', function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         presets: {
                             'christmas 2012': {
                                 startDate: christmas2012Str
@@ -145,7 +149,9 @@ define([
                 });
 
                 it('triggers an "onRendered" event on the daterangepicker', function() {
-                    picker = daterangepicker.create();
+                    picker = daterangepicker.create({
+                        $input: $testInput
+                    });
 
                     sinon.spy(picker, 'trigger');
 
@@ -226,6 +232,7 @@ define([
                 it('closes the picker when clicking close button', function(){
                     var hideSpy;
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         presets: {
                             'christmas 2012': {
                                 startDate: christmas2012Str
@@ -314,6 +321,7 @@ define([
                 describe('defaults', function(){
                     beforeEach(function(){
                         picker = daterangepicker.create({
+                            $input: $testInput,
                             singleDate: true
                         });
                     });
@@ -337,6 +345,7 @@ define([
                 describe('custom date supplied in options', function(){
                     beforeEach(function(){
                         picker = daterangepicker.create({
+                            $input: $testInput,
                             startDate: '2013-01-01',
                             singleDate: true
                         });
@@ -366,6 +375,7 @@ define([
                         };
 
                         picker = daterangepicker.create({
+                            $input: $testInput,
                             presets: presets,
                             singleDate: true
                         });
@@ -380,6 +390,7 @@ define([
 
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         singleDate: true
                     });
 
@@ -409,6 +420,7 @@ define([
             describe('events', function(){
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         startDate: '2012-12-25',
                         singleDate: true
                     });
@@ -440,6 +452,7 @@ define([
             describe('presets', function(){
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         presets: {
                             'christmas 2012': {
                                 startDate: christmas2012Str
@@ -525,7 +538,9 @@ define([
 
                 describe('defaults', function(){
                     beforeEach(function(){
-                        picker = daterangepicker.create();
+                        picker = daterangepicker.create({
+                            $input: $testInput
+                        });
                     });
 
                     it('creates a calendar for the current month as this.startCalendar', function(){
@@ -562,6 +577,7 @@ define([
                 describe('custom range supplied in options', function(){
                     beforeEach(function(){
                         picker = daterangepicker.create({
+                            $input: $testInput,
                             startDate: '2013-01-01',
                             endDate: '2013-02-14'
                         });
@@ -604,6 +620,7 @@ define([
                         };
 
                         picker = daterangepicker.create({
+                            $input: $testInput,
                             presets: presets
                         });
 
@@ -618,6 +635,7 @@ define([
 
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         doneButtonCssClass: 'customDoneButtonCss'
                     });
 
@@ -663,6 +681,7 @@ define([
             describe('events', function(){
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         startDate: '2012-12-25',
                         endDate: '2012-12-31'
                     });
@@ -786,6 +805,7 @@ define([
 
                 beforeEach(function(){
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         startDate: '2012-12-01',
                         endDate: '2012-12-31'
                     });
@@ -834,6 +854,7 @@ define([
                         nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
 
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         presets: {
                             'christmas 2012': {
                                 startDate: christmas2012Str,
@@ -915,7 +936,12 @@ define([
             });
 
             afterEach(function(){
-                input.data('picker').destroy();
+                var picker = input.data('picker');
+
+                if (picker) {
+                    picker.destroy();
+                }
+
                 $('#testArea').empty();
             });
 
@@ -927,6 +953,14 @@ define([
                 var picker = input.data('picker');
 
                 expect(picker.$input.data('picker')).toEqual(input.data('picker'));
+            });
+
+            it('removes the reference to the target element when destroyed', function() {
+                var picker = input.data('picker');
+
+                picker.destroy();
+
+                expect(input.data('picker')).not.toBeDefined();
             });
 
             it('passes supplied options through to the picker', function(){
@@ -1025,6 +1059,7 @@ define([
                 TestPlugin.prototype.attach = sinon.spy();
 
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [TestPlugin],
                     testPlugin: {
                         property1: true
@@ -1038,7 +1073,9 @@ define([
             });
 
             it('can add plugins', function(){
-                picker = daterangepicker.create();
+                picker = daterangepicker.create({
+                    $input: $testInput
+                });
 
                 function TestPlugin(options){
                     this.options = options;
@@ -1059,6 +1096,7 @@ define([
                     detachSpy = sinon.spy();
 
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [
                         _.extend(function TestPlugin(){
                             return {attach: attachSpy, detach: detachSpy};

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -11,8 +11,9 @@ define([
 
     describe('daterangepicker', function(){
         var picker;
-        var christmas2012Str = moment.utc([2012,11,25]).format('YYYY-MM-DD');
-        var nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
+        var timezone = 'Australia/Canberra';
+        var christmas2012Str = moment.tz([2012,11,25], timezone).format('YYYY-MM-DD');
+        var nye2012Str = moment.tz([2012,11,31], timezone).format('YYYY-MM-DD');
         var $testInput = $('<input type="text">');
 
         afterEach(function(){
@@ -31,7 +32,8 @@ define([
                 });
                 calendar = picker._createCalendar({
                     selectedDate: '2012-12-25',
-                    className: 'myCalendar'
+                    className: 'myCalendar',
+                    timezone: timezone
                 });
             });
 
@@ -46,11 +48,11 @@ define([
 
             describe('initialization', function(){
                 it('stores the selected date', function(){
-                    expect(calendar.selectedDate.toString()).toEqual(moment.utc([2012,11,25]).toString());
+                    expect(calendar.selectedDate.toString()).toEqual(moment.tz([2012,11,25], timezone).toString());
                 });
 
                 it('stores the selected month', function(){
-                    expect(calendar.monthToDisplay.toString()).toEqual(moment.utc([2012,11,1]).toString());
+                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
                 });
 
                 it('sets this.$el to be an empty div', function(){
@@ -259,7 +261,7 @@ define([
                 it('updates this.monthToDisplay', function(){
                     calendar.showMonth(2010,0);
 
-                    expect(calendar.monthToDisplay.toString()).toEqual(moment.utc([2010,0]).toString());
+                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2010,0], timezone).toString());
                 });
 
                 it('re-renders', function(){
@@ -277,8 +279,8 @@ define([
                 });
 
                 it('highlights from the start to the end of the month if the end date is next month', function(){
-                    var startDate = moment.utc([2012,11,30]),
-                        endDate = moment.utc([2013,0,2]);
+                    var startDate = moment.tz([2012,11,30], timezone);
+                    var endDate = moment.tz([2013,0,2], timezone);
 
                     calendar.highlightCells(startDate, endDate);
 
@@ -287,8 +289,8 @@ define([
                 });
 
                 it('highlights from the end date to the start of the month if the start date is previous month', function(){
-                    var startDate = moment.utc([2012,10,30]),
-                        endDate = moment.utc([2012,11,2]);
+                    var startDate = moment.tz([2012,10,30], timezone);
+                    var endDate = moment.tz([2012,11,2], timezone);
 
                     calendar.highlightCells(startDate, endDate);
 
@@ -297,8 +299,8 @@ define([
                 });
 
                 it('highlights the range if both start and end are in the displayed month', function(){
-                    var startDate = moment.utc([2012,11,24]),
-                        endDate = moment.utc([2012,11,30]);
+                    var startDate = moment.tz([2012,11,24], timezone);
+                    var endDate = moment.tz([2012,11,30], timezone);
 
                     calendar.highlightCells(startDate, endDate);
 
@@ -422,7 +424,8 @@ define([
                     picker = daterangepicker.create({
                         $input: $testInput,
                         startDate: '2012-12-25',
-                        singleDate: true
+                        singleDate: true,
+                        timezone: timezone
                     });
                     picker.render();
                 });
@@ -433,7 +436,7 @@ define([
                     picker.startCalendar.trigger('onDateSelected', { date: '2012-12-01' });
 
                     expect(highlightRangeSpy.calledOnce).toEqual(true);
-                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.utc([2012,11,1]).toString());
+                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
                     expect(highlightRangeSpy.args[0][1].toString()).toEqual(picker.getEndDate().toString());
                 });
 
@@ -445,7 +448,7 @@ define([
                     picker.startCalendar.$el.find('.day[data-date="2012-12-01"]').click();
 
                     expect(spy.calledOnce).toEqual(true);
-                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.utc([2012,11,1]).toString());
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
                 });
             });
 
@@ -462,7 +465,8 @@ define([
                                 specifyTime: true
                             }
                         },
-                        singleDate: true
+                        singleDate: true,
+                        timezone: timezone
                     });
 
                     picker.render();
@@ -481,7 +485,7 @@ define([
                 });
 
                 it('selects the corresponding date when a preset is clicked', function(){
-                    var christmas2012 = moment.utc([2012,11,25]);
+                    var christmas2012 = moment.tz([2012,11,25], timezone);
 
                     picker.$el.find('.presets li').eq(0).click();
 
@@ -491,7 +495,7 @@ define([
 
                 it('triggers a presetSelected event when a preset is chosen', function(){
                     var spy = sinon.spy(),
-                        christmas2012 = moment.utc([2012,11,25]);
+                        christmas2012 = moment.tz([2012,11,25], timezone);
 
                     picker.bind('presetSelected', spy);
 
@@ -504,7 +508,7 @@ define([
 
                 it('passes specifyTime as true if set to true on the preset', function() {
                     var spy = sinon.spy(),
-                        nye2012Str = moment.utc([2012,11,31]);
+                        nye2012Str = moment.tz([2012,11,31], timezone);
 
                     picker.bind('presetSelected', spy);
 
@@ -518,7 +522,7 @@ define([
 
                 it('passes specifyTime as false if set to false on the preset', function() {
                     var spy = sinon.spy(),
-                        christmas2012 = moment.utc([2012,11,25]);
+                        christmas2012 = moment.tz([2012,11,25], timezone);
 
                     picker.bind('presetSelected', spy);
 
@@ -683,7 +687,8 @@ define([
                     picker = daterangepicker.create({
                         $input: $testInput,
                         startDate: '2012-12-25',
-                        endDate: '2012-12-31'
+                        endDate: '2012-12-31',
+                        timezone: timezone
                     });
                     picker.render();
                 });
@@ -706,7 +711,7 @@ define([
                     picker.startCalendar.trigger('onDateSelected', { date: '2012-12-01' });
 
                     expect(highlightRangeSpy.calledOnce).toEqual(true);
-                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.utc([2012,11,1]).toString());
+                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
                     expect(highlightRangeSpy.args[0][1].toString()).toEqual(picker.getEndDate().toString());
                 });
 
@@ -716,8 +721,8 @@ define([
                     picker.endCalendar.trigger('onDateSelected', { date: '2012-12-30' });
 
                     expect(highlightRangeSpy.calledOnce).toEqual(true);
-                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.utc([2012,11,25]).toString());
-                    expect(highlightRangeSpy.args[0][1].toString()).toEqual(moment.utc([2012,11,30]).toString());
+                    expect(highlightRangeSpy.args[0][0].toString()).toEqual(moment.tz([2012,11,25], timezone).toString());
+                    expect(highlightRangeSpy.args[0][1].toString()).toEqual(moment.tz([2012,11,30], timezone).toString());
                 });
 
                 it('triggers a startDateSelected event when the startCalendar date changes', function(){
@@ -728,7 +733,7 @@ define([
                     picker.startCalendar.$el.find('.day[data-date="2012-12-01"]').click();
 
                     expect(spy.calledOnce).toEqual(true);
-                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.utc([2012,11,1]).toString());
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
                 });
 
                 it('triggers a endDateSelected event when the endCalendar date changes', function(){
@@ -739,7 +744,7 @@ define([
                     picker.endCalendar.$el.find('.day[data-date="2012-12-30"]').click();
 
                     expect(spy.calledOnce).toEqual(true);
-                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.utc([2012,11,30]).toString());
+                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.tz([2012,11,30], timezone).toString());
                 });
 
                 it('triggers endDateSelected with corrected date when end date before start date', function(){
@@ -750,8 +755,8 @@ define([
                     picker.endCalendar.$el.find('.day[data-date="2012-12-20"]').click();
 
                     expect(spy.calledOnce).toEqual(true);
-                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.utc([2012,11,20]).toString());
-                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.utc([2012,11,20]).toString());
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.tz([2012,11,20], timezone).toString());
+                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.tz([2012,11,20], timezone).toString());
                 });
 
                 it('triggers startDateSelected with corrected date when start date after end date', function(){
@@ -764,8 +769,8 @@ define([
                     picker.startCalendar.$el.find('.day[data-date="2012-12-31"]').click();
 
                     expect(spy.calledOnce).toEqual(true);
-                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.utc([2012,11,31]).toString());
-                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.utc([2012,11,31]).toString());
+                    expect(spy.args[0][0].startDate.toString()).toEqual(moment.tz([2012,11,31], timezone).toString());
+                    expect(spy.args[0][0].endDate.toString()).toEqual(moment.tz([2012,11,31], timezone).toString());
                 });
 
                 it('does not trigger onDateSelected on the other calendar when fixing start date', function(){
@@ -807,7 +812,8 @@ define([
                     picker = daterangepicker.create({
                         $input: $testInput,
                         startDate: '2012-12-01',
-                        endDate: '2012-12-31'
+                        endDate: '2012-12-31',
+                        timezone: timezone
                     });
                     picker.render();
 
@@ -816,8 +822,8 @@ define([
                 });
 
                 it('calls this.startCalendar.highlightCells with the correct dates', function(){
-                    var startDate = moment.utc([2012,11,1]),
-                        endDate = moment.utc([2012,11,31]);
+                    var startDate = moment.tz([2012,11,1], timezone),
+                        endDate = moment.tz([2012,11,31], timezone);
 
                     picker._highlightRange(startDate, endDate);
 
@@ -827,8 +833,8 @@ define([
                 });
 
                 it('calls this.endCalendar.highlightCells with the correct dates', function(){
-                    var startDate = moment.utc([2012,11,1]),
-                        endDate = moment.utc([2012,11,31]);
+                    var startDate = moment.tz([2012,11,1], timezone),
+                        endDate = moment.tz([2012,11,31], timezone);
 
                     picker._highlightRange(startDate, endDate);
 
@@ -838,8 +844,8 @@ define([
                 });
 
                 it('does not call either calendar\'s highlight cells method if an invalid date range is used', function(){
-                    var startDate = moment.utc([2012,11,31]),
-                        endDate = moment.utc([2012,11,1]);
+                    var startDate = moment.tz([2012,11,31], timezone),
+                        endDate = moment.tz([2012,11,1], timezone);
 
                     picker._highlightRange(startDate, endDate);
 
@@ -850,8 +856,8 @@ define([
 
             describe('presets', function(){
                 beforeEach(function(){
-                    var christmas2012Str = moment.utc([2012,11,25]).format('YYYY-MM-DD'),
-                        nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
+                    var christmas2012Str = moment.tz([2012,11,25], timezone).format('YYYY-MM-DD'),
+                        nye2012Str = moment.tz([2012,11,31], timezone).format('YYYY-MM-DD');
 
                     picker = daterangepicker.create({
                         $input: $testInput,
@@ -865,7 +871,8 @@ define([
                                 endDate: nye2012Str,
                                 specifyTime: true
                             }
-                        }
+                        },
+                        timezone: timezone
                     });
 
                     picker.render();
@@ -886,7 +893,7 @@ define([
                 });
 
                 it('selects the corresponding date range when a preset is clicked', function(){
-                    var christmas2012 = moment.utc([2012,11,25]);
+                    var christmas2012 = moment.tz([2012,11,25], timezone);
 
                     picker.$el.find('.presets li').eq(0).click();
 
@@ -896,7 +903,7 @@ define([
 
                 it('triggers a presetSelected event when a preset is chosen', function(){
                     var spy = sinon.spy(),
-                        christmas2012 = moment.utc([2012,11,25]);
+                        christmas2012 = moment.tz([2012,11,25], timezone);
 
                     picker.bind('presetSelected', spy);
 
@@ -911,8 +918,8 @@ define([
 
         describe('as a jquery plugin', function(){
             var input,
-                christmas2012Str = moment.utc([2012,11,25]).format('YYYY-MM-DD'),
-                nye2012Str = moment.utc([2012,11,31]).format('YYYY-MM-DD');
+                christmas2012Str = moment.tz([2012,11,25], timezone).format('YYYY-MM-DD'),
+                nye2012Str = moment.tz([2012,11,31], timezone).format('YYYY-MM-DD');
 
             beforeEach(function(){
                 input = $('<input id="pickerInput"/>');
@@ -931,7 +938,8 @@ define([
                             startDate: nye2012Str,
                             endDate: nye2012Str
                         }
-                    }
+                    },
+                    timezone: timezone
                 });
             });
 
@@ -968,8 +976,8 @@ define([
 
                 var picker = input.data('picker');
 
-                expect(picker.startCalendar.selectedDate.toString()).toEqual(moment.utc([2013,0,1]).toString());
-                expect(picker.endCalendar.selectedDate.toString()).toEqual(moment.utc([2013,1,14]).toString());
+                expect(picker.startCalendar.selectedDate.toString()).toEqual(moment.tz([2013,0,1], timezone).toString());
+                expect(picker.endCalendar.selectedDate.toString()).toEqual(moment.tz([2013,1,14], timezone).toString());
             });
 
             it('shows the picker when the target element is clicked', function(){
@@ -1042,8 +1050,8 @@ define([
                 var picker = input.data('picker');
 
                 picker.trigger('refresh', {
-                    startDate: moment([2014, 10, 12]),
-                    endDate: moment([2014, 11, 12])
+                    startDate: moment.tz([2014, 10, 12], timezone),
+                    endDate: moment.tz([2014, 11, 12], timezone)
                 });
 
                 expect(input.val()).toEqual('12 Nov 2014 - 12 Dec 2014');

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -342,6 +342,10 @@ define([
                         expect(picker.startCalendar.selectedDate.month()).toEqual(now.month());
                         expect(picker.startCalendar.selectedDate.date()).toEqual(now.date());
                     });
+
+                    it('parses dates in UTC if a timezone is not supplied', function(){
+                        expect(picker.timezone).toEqual('UTC');
+                    });
                 });
 
                 describe('custom date supplied in options', function(){
@@ -575,6 +579,10 @@ define([
                         expect(picker.endCalendar.selectedDate.year()).toEqual(now.year());
                         expect(picker.endCalendar.selectedDate.month()).toEqual(now.month());
                         expect(picker.endCalendar.selectedDate.date()).toEqual(now.date());
+                    });
+
+                    it('parses dates in UTC if a timezone is not supplied', function(){
+                        expect(picker.timezone).toEqual('UTC');
                     });
                 });
 

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -69,7 +69,7 @@ define([
             });
 
             describe('when a timezone is provided', function(){
-                var timezone = moment().format('UTCZ');
+                var timezone = moment.tz.names()[0];
 
                 beforeEach(function() {
                     picker = daterangepicker.create({
@@ -90,14 +90,20 @@ define([
 
         describe('plugin options', function() {
             describe('when specifyTimeChecked is true', function() {
+                var timezone = 'Europe/Helsinki';
+                var startDate;
+                var endDate;
+
                 beforeEach(function() {
-                    sandbox.useFakeTimers(Date.UTC(2013, 7, 1, 11, 0));
+                    startDate = moment.utc([2013, 7, 1, 11, 0]);
+                    endDate = moment.utc([2013, 7, 1, 11, 0]);
 
                     picker = daterangepicker.create({
                         $input: $testInput,
-                        startDate: moment().utcOffset(120).toISOString(),
-                        endDate: moment().utcOffset(120).add({'h': 2}).toISOString(),
+                        startDate: startDate.toISOString(),
+                        endDate: endDate.toISOString(),
                         plugins: [timesupport],
+                        timezone: timezone,
                         timeSupport: {
                             specifyTimeChecked: true
                         }
@@ -114,9 +120,9 @@ define([
                     expect(picker.$el.find('.time-support__panel-wrapper').hasClass('isOpen')).toEqual(true);
                 });
 
-                it('populates the time fields with UTC time', function() {
-                    expect(picker.timeSupport.startPanel.$input.val()).toEqual('11:00');
-                    expect(picker.timeSupport.endPanel.$input.val()).toEqual('13:00');
+                it('populates the time fields with time in the timezone passed as parameter', function() {
+                    expect(picker.timeSupport.startPanel.$input.val()).toEqual(startDate.tz(timezone).format('HH:mm'));
+                    expect(picker.timeSupport.endPanel.$input.val()).toEqual(endDate.tz(timezone).format('HH:mm'));
                 });
             });
 

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -12,8 +12,9 @@ define([
     'use strict';
 
     describe('time support plugin', function() {
-        var picker,
-            sandbox;
+        var picker;
+        var sandbox;
+        var $testInput = $('<input type="text">');
 
         beforeEach(function() {
             sandbox = sinon.sandbox.create();
@@ -32,6 +33,7 @@ define([
             it('throws if used on a "single date" picker', function() {
                 expect(function(){
                     daterangepicker.create({
+                        $input: $testInput,
                         singleDate: true,
                         plugins: [timesupport]
                     });
@@ -42,6 +44,7 @@ define([
         describe('when attached', function() {
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -70,6 +73,7 @@ define([
 
                 beforeEach(function() {
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         timezone: timezone,
                         plugins: [timesupport]
                     });
@@ -90,6 +94,7 @@ define([
                     sandbox.useFakeTimers(Date.UTC(2013, 7, 1, 11, 0));
 
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         startDate: moment().utcOffset(120).toISOString(),
                         endDate: moment().utcOffset(120).add({'h': 2}).toISOString(),
                         plugins: [timesupport],
@@ -118,6 +123,7 @@ define([
             describe('when specifyTimeChecked is false', function() {
                 beforeEach(function() {
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         plugins: [timesupport],
                         timeSupport: {
                             specifyTimeChecked: false
@@ -139,6 +145,7 @@ define([
             describe('when specifyTimeChecked is undefined', function() {
                 beforeEach(function() {
                     picker = daterangepicker.create({
+                        $input: $testInput,
                         plugins: [timesupport]
                     });
 
@@ -181,6 +188,7 @@ define([
 
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
             });
@@ -211,6 +219,7 @@ define([
 
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -260,6 +269,7 @@ define([
 
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -317,6 +327,7 @@ define([
 
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -351,6 +362,7 @@ define([
 
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport],
                     presets: {
                         'last hour': {
@@ -444,6 +456,7 @@ define([
         describe('when detached', function() {
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -464,6 +477,7 @@ define([
         describe('updating the calendar date', function() {
             beforeEach(function() {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -488,6 +502,7 @@ define([
 
             beforeEach(function () {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 
@@ -512,6 +527,7 @@ define([
         describe('closePanel', function () {
             beforeEach(function () {
                 picker = daterangepicker.create({
+                    $input: $testInput,
                     plugins: [timesupport]
                 });
 

--- a/test/index.html
+++ b/test/index.html
@@ -39,6 +39,7 @@
                 'jquery': 'vendor/jquery/dist/jquery',
                 'underscore': 'vendor/underscore/underscore',
                 'moment': 'vendor/moment/moment',
+                'moment-timezone': 'vendor/moment-timezone/builds/moment-timezone-with-data',
                 'timepicker': 'vendor/timepicker/lib/timepicker/timepicker',
                 'sinon': 'node_modules/sinon/pkg/sinon'
             },


### PR DESCRIPTION
Quite simply the dates and times displayed in the daterangepicker are now parsed in the timezone passed to it before being passed to the formatter. For a visual explanation, see the example added to the demo page. ([gif](https://cloud.githubusercontent.com/assets/167537/8109792/08bc705c-1059-11e5-9f04-2fb31532b4d8.gif))
If no timezone is specified, UTC is used, which makes this backwards-compatible.
I have broken down the changes into commits as small and meaningful as possible, doing minor cleanup and refactoring on the way and also using "one `var` per line" in the lines I changed (I didn't change all of them to keep the diff readable).