### PR TITLE
Format Time Zone Name Inside Time Zone Span

### DIFF
--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -172,7 +172,7 @@
         },
 
         setTimezone: function(timezone) {
-            this.$timezoneSpan.text('(' + timezone + ')');
+            this.$timezoneSpan.text('(' + timezone.replace(/_/gi, ' ') + ')');
         },
 
         getEndTimePicker: function () {

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -356,8 +356,8 @@ define([
             describe('setTimezone', function () {
                 it('changes the timezone displayed in the timepicker', function () {
                     expect(timeSupport.$timezoneSpan.text()).toEqual('(UTC)');
-                    timeSupport.setTimezone('Europe/Helsinki');
-                    expect(timeSupport.$timezoneSpan.text()).toEqual('(Europe/Helsinki)');
+                    timeSupport.setTimezone('America/Los_Angeles');
+                    expect(timeSupport.$timezoneSpan.text()).toEqual('(America/Los Angeles)');
                 });
             });
         });


### PR DESCRIPTION
Get rid of underscores inside time zone names.

![screen shot 2015-07-06 at 11 11 42](https://cloud.githubusercontent.com/assets/1322687/8519664/a800a55a-23d4-11e5-86da-4f5803711172.png)

->

![screen shot 2015-07-06 at 11 46 19]
(https://cloud.githubusercontent.com/assets/1322687/8519665/a805dc0a-23d4-11e5-8b1c-769c1b99a8c7.png)

