### PR TITLE
The date picker's TZ should be displayed as an offset, not a location string

### DIFF
--- a/lib/daterangepicker/daterangepicker.timesupport.js
+++ b/lib/daterangepicker/daterangepicker.timesupport.js
@@ -172,7 +172,9 @@
         },
 
         setTimezone: function(timezone) {
-            this.$timezoneSpan.text('(' + timezone.replace(/_/gi, ' ') + ')');
+            var isUTC = timezone.indexOf('UTC') !== -1;
+            var tzOffset = isUTC ? '(UTC)' : moment.tz(timezone).format('(UTCZ)');
+            this.$timezoneSpan.text(tzOffset);
         },
 
         getEndTimePicker: function () {

--- a/test/daterangepicker.timesupport.tests.js
+++ b/test/daterangepicker.timesupport.tests.js
@@ -68,8 +68,8 @@ define([
                 expect(picker.$el.find('.time-support__panel-wrapper .time-support__panel').length).toEqual(2);
             });
 
-            describe('when a timezone is provided', function(){
-                var timezone = moment.tz.names()[0];
+            describe('when a UTC-like timezone is provided', function() {
+                var timezone = 'Etc/UTC';
 
                 beforeEach(function() {
                     picker = daterangepicker.create({
@@ -83,7 +83,32 @@ define([
 
                 it('renders it inside a span', function() {
                     expect(picker.$el.find('.time-support__zone').length).toEqual(1);
-                    expect(picker.$el.find('.time-support__zone').text()).toEqual('(' + timezone + ')');
+                    expect(picker.$el.find('.time-support__zone').text()).toEqual('(UTC)');
+                });
+            });
+
+            describe('when a not-UTC timezone is provided', function(){
+                var timezone = 'Europe/Helsinki';
+                var clock;
+
+                beforeEach(function() {
+                    clock = sandbox.useFakeTimers(new Date('2015-01-01T00:00:00.000Z').getTime());
+                    picker = daterangepicker.create({
+                        $input: $testInput,
+                        timezone: timezone,
+                        plugins: [timesupport]
+                    });
+
+                    picker.render();
+                });
+
+                afterEach(function() {
+                    clock.restore();
+                });
+
+                it('renders its UTC offset inside a span', function() {
+                    expect(picker.$el.find('.time-support__zone').length).toEqual(1);
+                    expect(picker.$el.find('.time-support__zone').text()).toEqual('(UTC+02:00)');
                 });
             });
         });
@@ -354,10 +379,20 @@ define([
             });
 
             describe('setTimezone', function () {
-                it('changes the timezone displayed in the timepicker', function () {
+                var clock;
+
+                beforeEach(function() {
+                    clock = sandbox.useFakeTimers(new Date('2015-01-01T00:00:00.000Z').getTime());
+                });
+
+                afterEach(function() {
+                    clock.restore();
+                });
+
+                it('changes the timezone\'s offset displayed in the timepicker', function () {
                     expect(timeSupport.$timezoneSpan.text()).toEqual('(UTC)');
                     timeSupport.setTimezone('America/Los_Angeles');
-                    expect(timeSupport.$timezoneSpan.text()).toEqual('(America/Los Angeles)');
+                    expect(timeSupport.$timezoneSpan.text()).toEqual('(UTC-08:00)');
                 });
             });
         });


### PR DESCRIPTION
When specifying a time user should see an offset of the date picker's
timezone (UTC+02:00), not a location string (Europe/Amsterdam).

*Before*:
![screen shot 2015-08-13 at 12 09 18](https://cloud.githubusercontent.com/assets/6764396/9247590/da9ac290-41b4-11e5-85ec-64c6d5669b5f.png)

*After*:
![screen shot 2015-08-13 at 12 08 34](https://cloud.githubusercontent.com/assets/6764396/9247603/ebc9ab1c-41b4-11e5-98c9-ec0a0d473ec0.png)

