### PR TITLE
Fix "impossible timestamp" in Egypt timezone - Version 1

### DIFF
--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -165,7 +165,7 @@
 
                     if(date.month() !== monthToDisplayIndex){
                         classes.push('grey');
-                    } else if (date.toString() === selectedDate.toString()){
+                    } else if (date.date() === selectedDate.date()){
                         classes.push('selected');
                     }
 
@@ -174,6 +174,7 @@
                     }
                 },
                 weeksToShow = Math.ceil(lastDayOfMonthToDisplay.diff(rowStartDate, 'days')/7),
+                previousDate = null,
                 data = {
                     label: this.label ? '<span class="calendar-label">' + this.label + '</span>' : '',
                     monthTitle: this.monthToDisplay.format('MMMM YYYY'),
@@ -183,6 +184,12 @@
                                 var date = rowStartDate.clone().add({
                                     d: (weekIdx * 7) + (dayIdx + 1)
                                 });
+
+                                while (previousDate && previousDate.date() === date.date()) {
+                                    date.add({h: 1});
+                                }
+
+                                previousDate = date.clone();
 
                                 return {
                                     date: date.format('YYYY-MM-DD'),
@@ -219,15 +226,25 @@
         onNextClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.clone().add({M: 1});
-            this.showMonth(monthToShow.year(), monthToShow.month());
+            var oldMonth = this.monthToDisplay.clone();
+            this.monthToDisplay.add({M: 1});
+            while (this.monthToDisplay.month() === oldMonth.month()) {
+                this.monthToDisplay.add({h: 1});
+            }
+
+            this.showMonth();
         },
 
         onPreviousClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.subtract({M: 1});
-            this.showMonth(monthToShow.year(), monthToShow.month());
+            var oldMonth = this.monthToDisplay.clone();
+            this.monthToDisplay.subtract({M: 1});
+            while (this.monthToDisplay.month() === oldMonth.month()) {
+                this.monthToDisplay.subtract({h: 1});
+            }
+
+            this.showMonth();
         },
 
         updateSelectedDate: function(date, options){
@@ -240,7 +257,7 @@
                 silent = !!options.silent;
 
             if(month !== monthToDisplay.month() || year !== monthToDisplay.year()){
-                this.showMonth(year, month);
+                this.showMonth();
             }
 
             this.addMarker(this.selectedDate);
@@ -250,8 +267,7 @@
             }
         },
 
-        showMonth: function(year, month){
-            this.monthToDisplay = moment.tz([year, month, 1], this.timezone);
+        showMonth: function(){
             this.render();
 
             this.trigger('onMonthDisplayed', { month: this.monthToDisplay });

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -186,9 +186,9 @@ define([
 
                     previousMonthDate.click();
 
+                    expect(calendar.monthToDisplay.year()).toEqual(2012);
+                    expect(calendar.monthToDisplay.month()).toEqual(11);
                     expect(showMonthSpy.calledOnce).toEqual(true);
-                    expect(showMonthSpy.args[0][0]).toEqual(2012);
-                    expect(showMonthSpy.args[0][1]).toEqual(10);
                 });
 
                 it('updates this.selectedDate when a day is clicked', function(){
@@ -258,16 +258,10 @@ define([
                     calendar.render();
                 });
 
-                it('updates this.monthToDisplay', function(){
-                    calendar.showMonth(2010,0);
-
-                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2010,0], timezone).toString());
-                });
-
                 it('re-renders', function(){
                     var renderSpy = sinon.spy(calendar, 'render');
 
-                    calendar.showMonth(2010,0);
+                    calendar.showMonth();
 
                     expect(renderSpy.calledOnce).toEqual(true);
                 });


### PR DESCRIPTION
Under very rare circumstances, in certain timezones, after adding/subtracting a month/day to/from a moment object, we can end up at an "impossible timestamp" – a combination of date and time that can't exist because of a daylight-related shift. In this case, `moment` does not keep the hours on a date instance; instead, a shift occurs that may result in the new date still being the same month/day despite the increment.
 
Proposed fix includes:
– Consistently modifying `this.monthToDisplay` reference with `.add`/`.subtract`, not recreating it from scratch
– Checking for same day/same month case after each increment and patching it by adding an extra hour offset 

See http://momentjs.com/timezone/docs/#/using-timezones/parsing-ambiguous-inputs/