### PR TITLE
Fix "impossible timestamp" in Egypt timezone - Version 2

### DIFF
--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -90,7 +90,7 @@
         var timezone = this.timezone = options.timezone;
         var todayString = moment.tz(timezone).format('YYYY-MM-DD');
         var selectedDate = this.selectedDate = moment.tz(options.selectedDate, timezone);
-        var monthToDisplay = moment.tz([selectedDate.year(), selectedDate.month()], timezone);
+        var monthToDisplay = moment.tz([selectedDate.year(), selectedDate.month(), 1, 12], timezone);
 
         options = _.defaults(options, {
             selectedDate: todayString
@@ -165,7 +165,7 @@
 
                     if(date.month() !== monthToDisplayIndex){
                         classes.push('grey');
-                    } else if (date.toString() === selectedDate.toString()){
+                    } else if (date.date() === selectedDate.date()){
                         classes.push('selected');
                     }
 
@@ -219,15 +219,15 @@
         onNextClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.clone().add({M: 1});
-            this.showMonth(monthToShow.year(), monthToShow.month());
+            this.monthToDisplay.add({M: 1});
+            this.showMonth();
         },
 
         onPreviousClicked: function(e){
             e.stopPropagation();
 
-            var monthToShow = this.monthToDisplay.subtract({M: 1});
-            this.showMonth(monthToShow.year(), monthToShow.month());
+            this.monthToDisplay.subtract({M: 1});
+            this.showMonth();
         },
 
         updateSelectedDate: function(date, options){
@@ -240,7 +240,7 @@
                 silent = !!options.silent;
 
             if(month !== monthToDisplay.month() || year !== monthToDisplay.year()){
-                this.showMonth(year, month);
+                this.showMonth();
             }
 
             this.addMarker(this.selectedDate);
@@ -250,8 +250,7 @@
             }
         },
 
-        showMonth: function(year, month){
-            this.monthToDisplay = moment.tz([year, month, 1], this.timezone);
+        showMonth: function(){
             this.render();
 
             this.trigger('onMonthDisplayed', { month: this.monthToDisplay });

--- a/test/daterangepicker.tests.js
+++ b/test/daterangepicker.tests.js
@@ -52,7 +52,7 @@ define([
                 });
 
                 it('stores the selected month', function(){
-                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2012,11,1], timezone).toString());
+                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2012,11,1,12], timezone).toString());
                 });
 
                 it('sets this.$el to be an empty div', function(){
@@ -187,8 +187,8 @@ define([
                     previousMonthDate.click();
 
                     expect(showMonthSpy.calledOnce).toEqual(true);
-                    expect(showMonthSpy.args[0][0]).toEqual(2012);
-                    expect(showMonthSpy.args[0][1]).toEqual(10);
+                    expect(calendar.monthToDisplay.year()).toEqual(2012);
+                    expect(calendar.monthToDisplay.month()).toEqual(11);
                 });
 
                 it('updates this.selectedDate when a day is clicked', function(){
@@ -258,16 +258,10 @@ define([
                     calendar.render();
                 });
 
-                it('updates this.monthToDisplay', function(){
-                    calendar.showMonth(2010,0);
-
-                    expect(calendar.monthToDisplay.toString()).toEqual(moment.tz([2010,0], timezone).toString());
-                });
-
                 it('re-renders', function(){
                     var renderSpy = sinon.spy(calendar, 'render');
 
-                    calendar.showMonth(2010,0);
+                    calendar.showMonth();
 
                     expect(renderSpy.calledOnce).toEqual(true);
                 });


### PR DESCRIPTION
This is yet another approach to solve the problem described in CHAN-2346.

If we hit an "impossible timestamp" (see http://momentjs.com/timezone/docs/#/using-timezones/parsing-ambiguous-inputs/) (currently only happens for Egypt timezone), `moment` shifts the hours offset to the nearest "allowed" moment, and for Egypt we may end up on the same month/day. This is contradictory to the `moment` docs that guarantee the hours offset to be preserved in case of `add/.subtract` for days/months; in this rare case, however, the specific hours offset is "illegal" so it gets shifted.

To be protected from accidental time shifts made by moment for "impossible datestamps", we add 12 hours to the initial object representing the current month. If hours change (either way), the datestamp still remain on the same day/month (compared to previous behaviour where hours were 0).

Once moment shifts the hours, it also moved the date instance "away" from hitting the "impossible timestamp" the second time, and we assume no daylight adjustments will exceed 12 hours (thus the "magic number" 12). Smaller values like 3 or 4 would also work.