### PR TITLE
RR-127 Fix preset date selection

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,9 @@
                 todayStr = today.format('YYYY-MM-DD'),
                 yesterday = today.clone().subtract('days', 1),
                 yesterdayStr = yesterday.format('YYYY-MM-DD'),
-                sevenDaysAgoStr = today.clone().subtract('days', 6).format('YYYY-MM-DD');
+                sevenDaysAgoStr = today.clone().subtract('days', 6).format('YYYY-MM-DD'),
+                thirtyDaysAgoStr = today.clone().subtract('days', 29).format('YYYY-MM-DD'),
+                sixtyDaysAgoStr = today.clone().subtract('days', 59).format('YYYY-MM-DD');
         </script>
     </head>
     <body>
@@ -190,6 +192,14 @@
                             },
                             'last seven days': {
                                 startDate: sevenDaysAgoStr,
+                                endDate: todayStr
+                            },
+                            '30 days ago': {
+                                startDate: thirtyDaysAgoStr,
+                                endDate: todayStr
+                            },
+                            '60 days ago': {
+                                startDate: sixtyDaysAgoStr,
                                 endDate: todayStr
                             }
                         }

--- a/lib/daterangepicker/daterangepicker.js
+++ b/lib/daterangepicker/daterangepicker.js
@@ -240,6 +240,10 @@
                 silent = !!options.silent;
 
             if(month !== monthToDisplay.month() || year !== monthToDisplay.year()){
+                this.monthToDisplay.set({
+                    month: month,
+                    year: year
+                });
                 this.showMonth();
             }
 
@@ -526,7 +530,6 @@
             this.trigger('onBeforeShown', this);
 
             $el.show();
-            
             $el.css({
                 top: targetOffset.top + $target.outerHeight(),
                 left: left,


### PR DESCRIPTION
When using the preset date option in the datepicker, the start calendar wasn't being updated. This amusingly also caused a test to pass that probably shouldn't have. This PR restores the correct behaviour to the app and amends the test.