### PR TITLE
RR-934: Updating moment timezone version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jquery": "~3.1.0",
     "underscore": "~1.8.3",
     "moment": "~2.10.3",
-    "moment-timezone": "~0.3.1"
+    "moment-timezone": "~0.5.11"
   },
   "devDependencies": {
     "expectations": "~0.6.0",


### PR DESCRIPTION
Updating the version for moment-timezone.js in order to use moment.tz.guess() function.

Waiting for QA and review.